### PR TITLE
add Rust target support for PDS data.

### DIFF
--- a/Tools/pds_compress
+++ b/Tools/pds_compress
@@ -367,6 +367,37 @@ def formatc(f_out, pds):
             buf = ""
     f_out.write(textwrap.dedent(tmpl_c) % out);
 
+tmpl_rust = """\
+/// PDS (platform data set) is SiLab's solution to configuring the wifi chip.
+/// Options such as GPIO, PA power, number of antennae are configured with PDS.
+/// The data set here is "compiled" using a script (pds_compressy) that
+/// can be found in SiliconLabs github repository:
+/// https://github.com/SiliconLabs/wfx-fullMAC-tools/Tools/pds_compress
+/// 
+/// The output is meant to be redirected into a .rs file in the same crate as your
+/// hal driver, and pulled in with the appropriate mod/use statements.
+
+pub const PDS_DATA: [&[u8]; %d] = [
+%s];
+"""
+
+def formatrust(f_out, pds):
+    stack = 0
+    lines = 0
+    buf = ""
+    out = ""
+    for c in pds:
+        buf += c
+        if c == '{' or c == '[':
+            stack += 1
+        if c == '}' or c == ']':
+            stack -= 1
+        if (c == '}' or c == ']') and stack == 1:
+            lines += 1
+            out += '    b"{%s}\\0", \n' % buf[1:];
+            buf = ""
+    f_out.write(textwrap.dedent(tmpl_rust) % (lines, out));
+
 def formattiny(f_out, pds):
     stack = 0
     for c in pds:
@@ -408,6 +439,8 @@ def parse_cmdline(args=sys.argv[1:]):
                   help="shortcut for --out=pds")
     parser.add_argument("-t", action="store_const", const="tinypds", dest="out_format",
                   help="shortcut for --out=tinypds")
+    parser.add_argument("-r", action="store_const", const="rust", dest="out_format",
+                  help="shortcut for --out=rust")
     return parser.parse_args(args)
 
 def main(options):
@@ -447,6 +480,8 @@ def main(options):
         formattiny(options.output, re.sub(r'([-A-Za-z0-9]+)', r'"\1"', str_result))
     elif options.out_format == "c":
         formatc(options.output, str_result)
+    elif options.out_format == "rust":
+        formatrust(options.output, str_result)
     elif options.out_format == "tinypds":
         formattiny(options.output, str_result)
     elif options.out_format == "pds":

--- a/Tools/pds_compress
+++ b/Tools/pds_compress
@@ -368,11 +368,29 @@ def formatc(f_out, pds):
     f_out.write(textwrap.dedent(tmpl_c) % out);
 
 tmpl_rust = """\
+    /* AUTOMATICALLY GENERATED -- DO NOT EDIT BY HAND */
+    /*
+     * Copyright 2018, Silicon Laboratories Inc.  All rights reserved.
+     *
+     * Licensed under the Apache License, Version 2.0 (the "License");
+     * you may not use this file except in compliance with the License.
+     * You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     *
+     */
+
 /// PDS (platform data set) is SiLab's solution to configuring the wifi chip.
 /// Options such as GPIO, PA power, number of antennae are configured with PDS.
-/// The data set here is "compiled" using a script (pds_compressy) that
+/// The data set here is "compiled" using a script (pds_compress) that
 /// can be found in SiliconLabs github repository:
-/// https://github.com/SiliconLabs/wfx-fullMAC-tools/Tools/pds_compress
+/// https://github.com/SiliconLabs/wfx-linux-tools/blob/master/pds_compress
 /// 
 /// The output is meant to be redirected into a .rs file in the same crate as your
 /// hal driver, and pulled in with the appropriate mod/use statements.


### PR DESCRIPTION
hi! 

don't know if you're taking pull requests, but this pull request adds a --rust target to pds_compress so you can create a Rust-native module for the PDS.
