### PR TITLE
lwip: remove unnecessary assignments

### DIFF
--- a/Examples/SiliconLabs/commissioning/micrium_os/SLSTK3701A/src/lwip_host/ethernetif.c
+++ b/Examples/SiliconLabs/commissioning/micrium_os/SLSTK3701A/src/lwip_host/ethernetif.c
@@ -253,7 +253,6 @@ err_t sta_ethernetif_init(struct netif *netif)
 
   /* initialize the hardware */
   low_level_init(netif);
-  sta_netif = *netif;
 
   return ERR_OK;
 }
@@ -280,7 +279,6 @@ err_t ap_ethernetif_init(struct netif *netif)
 
   /* initialize the hardware */
   low_level_init(netif);
-  ap_netif = *netif;
 
   return ERR_OK;
 }


### PR DESCRIPTION
The `sta_ethernetif_init()` and `ap_ethernetif_init()` functions already receive pointers to `sta_netif` and `ap_netif` respectively.  The two assignments of `*netif` back to those globals isn't necessary.