### PR TITLE
lwip: bugfix for typos in lwip_host/ethernetif.c

### DIFF
--- a/Examples/SiliconLabs/commissioning/micrium_os/SLSTK3701A/src/lwip_host/ethernetif.c
+++ b/Examples/SiliconLabs/commissioning/micrium_os/SLSTK3701A/src/lwip_host/ethernetif.c
@@ -35,8 +35,8 @@
 #include <common/include/rtos_err.h>
 #include "sl_wfx_task.h"
 #include "sl_wfx_host.h"
-#define STATION_NETIF 'st'
-#define SOFTAP_NETIF  'ap'
+#define STATION_NETIF "st"
+#define SOFTAP_NETIF  "ap"
 
 /* wfx_fmac_driver context*/
 sl_wfx_context_t wifi_context;


### PR DESCRIPTION
Macros define invalid multibyte characters instead of 2-character strings.