### PR TITLE
Adding BRD2204C to boardCompatibility key for wifi_cli and secure_mqtt examples

### DIFF
--- a/templates.xml
+++ b/templates.xml
@@ -3,7 +3,7 @@
   <descriptors name="wifi_cli_micriumos" label="Platform - Wi-Fi CLI on Micrium OS kernel" description="This example project provides a Command Line Interface (CLI) to interact with the Wi-Fi FMAC driver and the LwIP APIs.">
     <properties key="namespace" value="template.uc"/>
     <properties key="projectFilePaths" value="wifi_cli_micriumos/wifi_cli_micriumos.slcp"/>
-    <properties key="boardCompatibility" value="brd2204a brd4161a brd4162a brd4163a brd4164a brd4321a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2204c brd2204a brd4161a brd4162a brd4163a brd4164a brd4321a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*efm32gg11b.* .*efr32mg12p.* .*wgm160.*"/>
     <properties key="ideCompatibility" value="makefile-ide simplicity-ide"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -13,7 +13,7 @@
   <descriptors name="secured_mqtt" label="Platform - Wi-Fi Secured MQTT on Micrium OS kernel" description="This example project demonstrates how to run a secured MQTT application with the Wi-Fi FMAC driver, the LwIP functionalities and the MbedTLS library.">
     <properties key="namespace" value="template.uc"/>
     <properties key="projectFilePaths" value="secured_mqtt/secured_mqtt.slcp"/>
-    <properties key="boardCompatibility" value="brd2204a brd4161a brd4162a brd4163a brd4164a brd4321a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2204c brd2204a brd4161a brd4162a brd4163a brd4164a brd4321a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*efm32gg11b.* .*efr32mg12p.* .*wgm160.*"/>
     <properties key="ideCompatibility" value="makefile-ide simplicity-ide"/>
     <properties key="toolchainCompatibility" value="gcc"/>


### PR DESCRIPTION
I was using BRD2204C board, but I didn't find any supported examples when I added this repo as "External Repo" in Simplicity Studio 5 .
I figured out that the "BRD2204C" is missing in the "templates.xml" file, in boardCompatibility key.
So, we need to add it the to file for the "wifi_cli" and "secure_mqtt" examples.